### PR TITLE
GitHub Actionsのマニフェスト作成コマンドを修正

### DIFF
--- a/.github/workflows/debian-fish-bookworm.yaml
+++ b/.github/workflows/debian-fish-bookworm.yaml
@@ -54,11 +54,11 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.CR_PAT }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - name: Create and push manifest
         run: |
-          docker manifest create \
-            ghcr.io/${{ github.repository_owner }}/${{ steps.container.outputs.image-name }}:${{ steps.container.outputs.tag }} \
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository_owner }}/${{ steps.container.outputs.image-name }}:${{ steps.container.outputs.tag }} \
             ghcr.io/${{ github.repository_owner }}/${{ steps.container.outputs.image-name }}:${{ steps.container.outputs.tag }}-arm64 \
             ghcr.io/${{ github.repository_owner }}/${{ steps.container.outputs.image-name }}:${{ steps.container.outputs.tag }}-amd64
-          
-          docker manifest push ghcr.io/${{ github.repository_owner }}/${{ steps.container.outputs.image-name }}:${{ steps.container.outputs.tag }}


### PR DESCRIPTION
問題：
- docker manifest コマンドが失敗していた

修正内容：
- docker buildx imagetools create を使用するように変更
- push-manifestジョブにDocker Buildxのセットアップを追加
- より安定したマルチプラットフォームマニフェスト作成方法に変更

🤖 Generated with [Claude Code](https://claude.ai/code)