### PR TITLE
個人情報を汎用化し、ビルド引数でカスタマイズ可能に

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,12 @@
 {
     "name": "debian-fish-bookworm",
     "image": "ghcr.io/bearfield/debian-fish:bookworm",
-    "remoteUser": "kumano_ryo",
+    "remoteUser": "devuser",
     "mounts": [
-        "source=${localEnv:HOME}/devcontainer_conf/.gitconfig_linux,target=/home/kumano_ryo/.gitconfig,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.config/gcloud,target=/home/kumano_ryo/.config/gcloud,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.ssh,target=/home/kumano_ryo/.ssh,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.claude,target=/home/kumano_ryo/.claude,type=bind,consistency=cached"
+        "source=${localEnv:HOME}/devcontainer_conf/.gitconfig_linux,target=/home/devuser/.gitconfig,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.config/gcloud,target=/home/devuser/.config/gcloud,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.ssh,target=/home/devuser/.ssh,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.claude,target=/home/devuser/.claude,type=bind,consistency=cached"
     ],
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Docker build configuration
+# Copy this file to .env and customize the values for your environment
+
+# Container user configuration
+USER_NAME=devuser
+USER_ID=1000
+GROUP_ID=1000
+
+# GitHub Container Registry configuration
+# Set this to your GitHub username or organization
+GITHUB_USER=your-github-username
+
+# Example usage:
+# make test USER_NAME=myuser USER_ID=1001
+# Or set these values in your .env file

--- a/.github/workflows/debian-fish-bookworm.yaml
+++ b/.github/workflows/debian-fish-bookworm.yaml
@@ -37,6 +37,10 @@ jobs:
           platforms: ${{ matrix.platform }}
           context: ./docker
           tags: ghcr.io/${{ github.repository_owner }}/${{ steps.container.outputs.image-name }}:${{ steps.container.outputs.tag }}-${{ matrix.platform == 'linux/arm64' && 'arm64' || 'amd64' }}
+          build-args: |
+            USER_NAME=${{ vars.CONTAINER_USER_NAME || 'devuser' }}
+            USER_ID=${{ vars.CONTAINER_USER_ID || '1000' }}
+            GROUP_ID=${{ vars.CONTAINER_GROUP_ID || vars.CONTAINER_USER_ID || '1000' }}
   
   push-manifest:
     name: Create and push multi-platform manifest

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .claude/
+.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,10 +68,10 @@ The devcontainer includes the following extensions:
 
 ### Mounted Volumes
 The devcontainer mounts several local directories:
-- `~/.gitconfig_linux` → `/home/kumano_ryo/.gitconfig`
-- `~/.config/gcloud` → `/home/kumano_ryo/.config/gcloud`
-- `~/.ssh` → `/home/kumano_ryo/.ssh`
-- `~/.claude` → `/home/kumano_ryo/.claude` (for Claude Code settings)
+- `~/.gitconfig_linux` → `/home/devuser/.gitconfig`
+- `~/.config/gcloud` → `/home/devuser/.config/gcloud`
+- `~/.ssh` → `/home/devuser/.ssh`
+- `~/.claude` → `/home/devuser/.claude` (for Claude Code settings)
 
 ## Development Workflow
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,13 @@ DOCKERHUB_REPONAME=ghcr.io/bearfield
 CONTAINER_NAME=debian-fish
 CONTAINER_TAG=test.bookworm
 
+# Build arguments with default values
+USER_NAME ?= devuser
+USER_ID ?= 1000
+GROUP_ID ?= $(USER_ID)
+
+# Build args for docker buildx
+BUILD_ARGS = --build-arg USER_NAME=$(USER_NAME) --build-arg USER_ID=$(USER_ID) --build-arg GROUP_ID=$(GROUP_ID)
 
 MAKEFILE_DIR=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 WORK_DIR=$(MAKEFILE_DIR)
@@ -9,12 +16,12 @@ WORK_DIR=$(MAKEFILE_DIR)
 .PHONY:test.build.arm64
 test.build.arm64:
 	cd $(WORK_DIR)
-	docker buildx build --tag=$(DOCKERHUB_REPONAME)/$(CONTAINER_NAME):$(CONTAINER_TAG).arm64 ./docker --platform linux/arm64
+	docker buildx build $(BUILD_ARGS) --tag=$(DOCKERHUB_REPONAME)/$(CONTAINER_NAME):$(CONTAINER_TAG).arm64 ./docker --platform linux/arm64
 
 .PHONY:test.build.amd64
 test.build.amd64:
 	cd $(WORK_DIR)
-	docker buildx build --tag=$(DOCKERHUB_REPONAME)/$(CONTAINER_NAME):$(CONTAINER_TAG).amd64 ./docker --platform linux/amd64
+	docker buildx build $(BUILD_ARGS) --tag=$(DOCKERHUB_REPONAME)/$(CONTAINER_NAME):$(CONTAINER_TAG).amd64 ./docker --platform linux/amd64
 
 .PHONY:test.rmi.arm64
 test.rmi.arm64:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,41 @@ make test.rmi.arm64
 make test.rmi.amd64
 ```
 
+## ビルドカスタマイズ
+
+### ビルド引数の使用
+コンテナ内のユーザー名やUIDをカスタマイズできます：
+
+```bash
+# ローカルビルド時の例
+make test USER_NAME=myuser USER_ID=1001 GROUP_ID=1001
+
+# 特定のアーキテクチャのみ
+make test.arm64 USER_NAME=myuser USER_ID=1001
+```
+
+### デフォルト値
+- `USER_NAME`: devuser
+- `USER_ID`: 1000
+- `GROUP_ID`: 1000
+
+### 環境変数の設定
+`.env.example`をコピーして`.env`を作成し、デフォルト値をカスタマイズできます：
+
+```bash
+cp .env.example .env
+# .envファイルを編集してカスタマイズ
+```
+
+### GitHub Actionsでのカスタマイズ
+リポジトリの設定で以下の変数を設定できます（Settings → Secrets and variables → Actions → Variables）：
+
+- `CONTAINER_USER_NAME`: コンテナ内のユーザー名
+- `CONTAINER_USER_ID`: ユーザーID
+- `CONTAINER_GROUP_ID`: グループID（設定しない場合はUSER_IDと同じ値）
+
+これらの変数を設定することで、GitHub Actionsでビルドされるイメージをカスタマイズできます。
+
 ## CI/CD
 
 このプロジェクトはGitHub Actionsを使用して自動ビルドを行います。

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,9 @@
 FROM debian:bookworm-slim
 #
 # set argument
-ARG USER_NAME=kumano_ryo
-ARG USER_ID=501
+# Default values for build arguments (can be overridden during build)
+ARG USER_NAME=devuser
+ARG USER_ID=1000
 ARG GROUP_ID=$USER_ID
 #
 # install packages and tools


### PR DESCRIPTION
## Summary
- Dockerfileのデフォルトユーザーを汎用的な値に変更
- ビルド時の引数によるカスタマイズ機能を追加
- GitHub Actionsでのリポジトリ変数サポート

## 変更内容

### 1. 個人情報の汎用化
- `USER_NAME`: `kumano_ryo` → `devuser`
- `USER_ID`: `501` (macOS固有) → `1000` (Linux標準)
- 全ての設定ファイルから個人名を削除

### 2. カスタマイズ機能の追加
- Makefileにビルド引数サポートを追加
  ```bash
  make test USER_NAME=myuser USER_ID=1001
  ```
- GitHub Actionsでリポジトリ変数による設定が可能
  - `CONTAINER_USER_NAME`
  - `CONTAINER_USER_ID`
  - `CONTAINER_GROUP_ID`

### 3. ドキュメントとサンプルファイル
- `.env.example`を追加（ローカル設定のテンプレート）
- README.mdにカスタマイズ方法を記載
- `.gitignore`に`.env`を追加

## Test plan
- [x] ローカルでデフォルト値でのビルドが成功すること
- [x] カスタム値でのビルドが成功すること
- [ ] GitHub Actionsでのビルドが成功すること

🤖 Generated with [Claude Code](https://claude.ai/code)