### PR TITLE
GitHub Actionsワークフローの重複を解消

### DIFF
--- a/.github/workflows/debian-fish-bookworm.yaml
+++ b/.github/workflows/debian-fish-bookworm.yaml
@@ -1,4 +1,9 @@
 name: debian-fish-bookworm docker container image creation
+
+env:
+  IMAGE_NAME: debian-fish
+  IMAGE_TAG: bookworm
+
 on:
   push:
     branches:
@@ -18,11 +23,6 @@ jobs:
           - linux/arm64
           - linux/amd64
     steps:
-      - name: Set container image name and tag
-        run: |
-          echo "image-name=debian-fish" >> $GITHUB_OUTPUT
-          echo "tag=bookworm" >> $GITHUB_OUTPUT
-        id: container
       - name: Check out the repo
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
@@ -39,7 +39,7 @@ jobs:
           push: true
           platforms: ${{ matrix.platform }}
           context: ./docker
-          tags: ghcr.io/${{ github.repository_owner }}/${{ steps.container.outputs.image-name }}:${{ steps.container.outputs.tag }}-${{ matrix.platform == 'linux/arm64' && 'arm64' || 'amd64' }}
+          tags: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-${{ matrix.platform == 'linux/arm64' && 'arm64' || 'amd64' }}
           build-args: |
             USER_NAME=${{ vars.CONTAINER_USER_NAME || 'devuser' }}
             USER_ID=${{ vars.CONTAINER_USER_ID || '1000' }}
@@ -50,11 +50,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-      - name: Set container image name and tag
-        run: |
-          echo "image-name=debian-fish" >> $GITHUB_OUTPUT
-          echo "tag=bookworm" >> $GITHUB_OUTPUT
-        id: container
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -66,6 +61,6 @@ jobs:
       - name: Create and push manifest
         run: |
           docker buildx imagetools create \
-            --tag ghcr.io/${{ github.repository_owner }}/${{ steps.container.outputs.image-name }}:${{ steps.container.outputs.tag }} \
-            ghcr.io/${{ github.repository_owner }}/${{ steps.container.outputs.image-name }}:${{ steps.container.outputs.tag }}-arm64 \
-            ghcr.io/${{ github.repository_owner }}/${{ steps.container.outputs.image-name }}:${{ steps.container.outputs.tag }}-amd64
+            --tag ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} \
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-arm64 \
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}-amd64


### PR DESCRIPTION
## Summary
GitHub Actionsワークフローで重複していたコンテナイメージ名とタグの設定を、環境変数として一元化しました。

## 問題点
buildジョブとpush-manifestジョブの両方で、同じ設定（image-name=debian-fish, tag=bookworm）を別々に定義していました：
```yaml
# 重複していた設定
- name: Set container image name and tag
  run: |
    echo "image-name=debian-fish" >> $GITHUB_OUTPUT
    echo "tag=bookworm" >> $GITHUB_OUTPUT
  id: container
```

## 解決方法
ワークフローレベルの環境変数を使用して設定を一元化：
```yaml
env:
  IMAGE_NAME: debian-fish
  IMAGE_TAG: bookworm
```

## 変更内容
1. ワークフローのトップレベルに`env`セクションを追加
2. 両ジョブから重複していた「Set container image name and tag」ステップを削除
3. `${{ steps.container.outputs.* }}`の参照を`${{ env.* }}`に置き換え

## 効果
- **DRY原則の適用**: 設定値が一箇所で管理される
- **保守性の向上**: イメージ名やタグを変更する際、1箇所の修正で済む
- **可読性の向上**: ワークフローの冒頭で設定値が明確に定義される
- **エラーリスクの低減**: 重複による不整合の可能性を排除

## Test plan
- [ ] GitHub Actionsのワークフローが正常に実行されること
- [ ] 環境変数が正しく参照されること
- [ ] ビルドされたイメージのタグが正しいこと

🤖 Generated with [Claude Code](https://claude.ai/code)