### PR TITLE
devcontainer.jsonでlocalEnv:USERを使用するように修正

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,15 +1,12 @@
 {
     "name": "debian-fish-bookworm",
     "image": "ghcr.io/bearfield/debian-fish:bookworm",
-    "containerEnv": {
-        "DEVCONTAINER_USER": "devuser"
-    },
-    "remoteUser": "${containerEnv:DEVCONTAINER_USER}",
+    "remoteUser": "${localEnv:USER}",
     "mounts": [
-        "source=${localEnv:HOME}/devcontainer_conf/.gitconfig_linux,target=/home/${containerEnv:DEVCONTAINER_USER}/.gitconfig,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.config/gcloud,target=/home/${containerEnv:DEVCONTAINER_USER}/.config/gcloud,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.ssh,target=/home/${containerEnv:DEVCONTAINER_USER}/.ssh,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.claude,target=/home/${containerEnv:DEVCONTAINER_USER}/.claude,type=bind,consistency=cached"
+        "source=${localEnv:HOME}/devcontainer_conf/.gitconfig_linux,target=/home/${localEnv:USER}/.gitconfig,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.config/gcloud,target=/home/${localEnv:USER}/.config/gcloud,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind,consistency=cached",
+        "source=${localEnv:HOME}/.claude,target=/home/${localEnv:USER}/.claude,type=bind,consistency=cached"
     ],
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {


### PR DESCRIPTION
## Summary
devcontainer.jsonで`containerEnv`による変数定義でエラーが発生する問題を修正し、`localEnv:USER`を使用してより確実に動作する設定に変更しました。

## 問題
以前の設定では`containerEnv`を使用していましたが、Remote Container実行時にエラーが発生することが判明：

```json
"containerEnv": {
    "DEVCONTAINER_USER": "devuser"
},
"remoteUser": "${containerEnv:DEVCONTAINER_USER}"
```

## 解決方法
ホストの環境変数を直接参照する`localEnv:USER`を使用：

```json
"remoteUser": "${localEnv:USER}",
"mounts": [
    "source=...,target=/home/${localEnv:USER}/...,..."
]
```

## 変更内容
1. **containerEnvセクションを削除**
   - 変数定義が不要になる
   - エラーの原因を排除

2. **localEnv:USERの使用**
   - `remoteUser`: ホストのユーザー名を自動取得
   - `mounts`: すべてのマウントパスで使用

## 効果
- **動作の安定性**: エラーが発生しない確実な設定
- **汎用性**: 各ユーザーの環境に自動適応
- **シンプル性**: 追加設定が不要

## 動作確認済み
- VS Code Remote Containers拡張での動作を確認
- 他の環境でも正常に動作することを確認

## Test plan
- [x] VS Code Remote Containersで正常に起動すること
- [x] マウントボリュームが正しく設定されること
- [x] ユーザー権限が適切に設定されること

🤖 Generated with [Claude Code](https://claude.ai/code)