### PR TITLE
Claude Code設定の改善: CLAUDE.mdのみをマウントするように変更

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
         "source=${localEnv:HOME}/devcontainer_conf/.gitconfig_linux,target=/home/${localEnv:USER}/.gitconfig,type=bind,consistency=cached",
         "source=${localEnv:HOME}/.config/gcloud,target=/home/${localEnv:USER}/.config/gcloud,type=bind,consistency=cached",
         "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.claude,target=/home/${localEnv:USER}/.claude,type=bind,consistency=cached"
+        "source=${localEnv:HOME}/.claude/CLAUDE.md,target=/home/${localEnv:USER}/.claude/CLAUDE.md,type=bind,consistency=cached"
     ],
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -142,6 +142,11 @@ RUN fisher install oh-my-fish/theme-bobthefish
 # copy config.fish
 COPY config.fish /home/$USER_NAME/.config/fish/config.fish
 
+# create .claude directory for Claude Code settings
+RUN mkdir -p /home/$USER_NAME/.claude && \
+    chown -R $USER_NAME:$USER_NAME /home/$USER_NAME/.claude && \
+    chmod 755 /home/$USER_NAME/.claude
+
 # set env
 ENV DEBIAN_FRONTEND=dialog
 LABEL org.opencontainers.image.source=https://github.com/bearfield/dot-devcontainer-debian-fish-bookworm


### PR DESCRIPTION
## Summary
- Dockerfileに`~/.claude`ディレクトリの事前作成処理を追加
- devcontainer.jsonのマウント設定を修正し、`CLAUDE.md`ファイルのみをマウントするように変更
- Claude Codeがコンテナ内で正常に動作できるように改善

## 変更内容

### Dockerfile
- `~/.claude`ディレクトリを作成し、適切なパーミッション(755)とオーナー設定を追加
- Claude Codeがローカル設定ファイルを書き込めるように対応

### devcontainer.json
- マウント設定を`~/.claude`ディレクトリ全体から`~/.claude/CLAUDE.md`ファイルのみに変更
- ホストの他のClaude設定ファイルの影響を受けない構成に

## 背景
コンテナ内でClaude Codeを使用する際、以下の要件を満たす必要がありました：
1. ホストの`~/.claude/CLAUDE.md`（グローバル設定）を参照できる
2. コンテナ内でClaude Codeがローカル設定を書き込める
3. ホストの他のClaude設定ファイルの影響を受けない

この変更により、上記の要件をすべて満たすことができます。

## Test plan
- [ ] コンテナをビルドして起動できることを確認
- [ ] コンテナ内で`~/.claude`ディレクトリが存在し、適切なパーミッションが設定されていることを確認
- [ ] ホストの`CLAUDE.md`がコンテナ内で参照できることを確認
- [ ] Claude Codeがコンテナ内で正常に動作することを確認

🤖 Generated with Claude Code