### PR TITLE
Python開発環境の追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,14 +49,36 @@ The Dockerfile (`docker/Dockerfile`) sets up:
 4. Cloud tools (Google Cloud SDK, AWS CLI, 1Password CLI)
 5. Docker CE installation
 6. Node.js and Claude Code CLI
-7. Python tools via uv (httpie for API testing, yq for YAML processing)
+7. Python 3.13 via uv with comprehensive development environment
 8. Fish shell plugins via Fisher
+
+### Python Development Environment
+- **Python Version**: 3.13 (latest stable version installed via uv)
+- **Package Manager**: uv (ultrafast Python package installer)
+- **Development Tools**:
+  - ruff: Fast Python linter and formatter
+  - mypy: Static type checker
+  - black: Code formatter
+  - pytest: Testing framework
+  - ipython: Enhanced interactive Python shell
+  - poetry: Dependency management and packaging
+  - pipx: Install Python applications in isolated environments
+  - httpie: API testing tool
+  - yq: YAML processor
+- **Environment Variables**:
+  - `PYTHONUNBUFFERED=1`: Real-time output in Docker logs
+  - `PYTHONDONTWRITEBYTECODE=1`: No .pyc files
+  - `UV_SYSTEM_PYTHON=1`: Allow system Python usage
 
 ### Fish Configuration
 - Located at `docker/config.fish`
 - Uses bobthefish theme with solarized color scheme
 - Includes timezone and date format customization
 - Sets up cloud SDK configuration
+- Python aliases for convenient command shortcuts:
+  - `py` → `python3`
+  - `pip` → `uv pip`
+  - `pytest`, `ruff`, `black`, `mypy`, `ipython` → respective uv tool commands
 
 ## DevContainer Configuration
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Create docker container 'ghcr.io/bearfield/debian-fish:bookworm' for development
 - Docker CE
 
 ### 開発環境
+- Python 3.13 (最新版) with uv package manager
 - Node.js & Claude Code CLI
 - Fish shell with bobthefish theme
 - VS Code Extensions (GitHub Copilot, Claude Code, etc.)
@@ -49,7 +50,8 @@ flowchart TD
     M --> N[クラウドツールインストール<br/>gcloud, aws-cli, op]
     N --> O[Docker CEインストール]
     O --> P[Node.js & Claude CLIインストール]
-    P --> Q[Fish設定適用<br/>config.fish, Fisher plugins]
+    P --> P2[Python 3.13 & 開発ツールインストール<br/>uv, ruff, mypy, black等]
+    P2 --> Q[Fish設定適用<br/>config.fish, Fisher plugins]
     Q --> R[ビルド完了]
     
     R --> S{自動クリーンアップ}
@@ -160,3 +162,37 @@ flowchart TD
 ```
 
 この並列アプローチにより、ビルド時間が約半分に短縮されます。
+
+## Python開発環境
+
+このコンテナには最新のPython開発環境が含まれています：
+
+### Python環境
+- **Python**: 3.13（最新安定版）
+- **パッケージマネージャ**: uv（超高速Pythonパッケージインストーラー）
+
+### インストール済み開発ツール
+- **ruff**: 高速なPythonリンター＆フォーマッター
+- **mypy**: 静的型チェッカー
+- **black**: コードフォーマッター
+- **pytest**: テストフレームワーク
+- **ipython**: 強化された対話型Pythonシェル
+- **poetry**: 依存関係管理・パッケージングツール
+- **pipx**: Pythonアプリケーションの独立インストール
+- **httpie**: HTTPクライアント（API開発用）
+- **yq**: YAML/JSON/XML/CSVプロセッサー
+
+### 環境変数
+- `PYTHONUNBUFFERED=1`: Dockerログのリアルタイム出力
+- `PYTHONDONTWRITEBYTECODE=1`: .pycファイルの生成を無効化
+- `UV_SYSTEM_PYTHON=1`: システムPythonの使用を許可
+
+### Fish shellエイリアス
+開発効率を上げるためのエイリアスが設定されています：
+- `py` → `python3`
+- `pip` → `uv pip`
+- `pytest` → `uv tool run pytest`
+- `ruff` → `uv tool run ruff`
+- `black` → `uv tool run black`
+- `mypy` → `uv tool run mypy`
+- `ipython` → `uv tool run ipython`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,6 +43,9 @@ RUN apt-get update \
         zip \
         unzip \
         python3 \
+        python3-dev \
+        build-essential \
+        libffi-dev \
 #
 # set locale
     && echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
@@ -123,11 +126,32 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-# install uv and python tools
+# install uv globally
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
-    && export PATH="/root/.local/bin:$PATH" \
-    && uv tool install httpie \
-    && uv tool install yq
+    && mv /root/.local/bin/uv /usr/local/bin/uv \
+    && chmod 755 /usr/local/bin/uv \
+    && rm -rf /root/.local
+# Install Python system-wide
+RUN export UV_PYTHON_INSTALL_DIR=/opt/uv/python \
+    && uv python install 3.13 \
+    && uv python pin 3.13 \
+    && ln -sf /opt/uv/python/cpython-3.13.*/bin/python3.13 /usr/local/bin/python3.13 \
+    && ln -sf /usr/local/bin/python3.13 /usr/local/bin/python3 \
+    && ln -sf /usr/local/bin/python3.13 /usr/local/bin/python \
+    && chmod -R 755 /opt/uv
+# Install Python tools as devuser
+USER $USER_NAME
+RUN uv tool install httpie \
+    && uv tool install yq \
+    && uv tool install ruff \
+    && uv tool install mypy \
+    && uv tool install black \
+    && uv tool install pytest \
+    && uv tool install ipython \
+    && uv tool install poetry \
+    && uv tool install pipx
+# Switch back to root
+USER root
 #
 # isntall fisher
 USER $USER_NAME
@@ -149,4 +173,8 @@ RUN mkdir -p /home/$USER_NAME/.claude && \
 
 # set env
 ENV DEBIAN_FRONTEND=dialog
+# Python environment variables
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV UV_SYSTEM_PYTHON=1
 LABEL org.opencontainers.image.source=https://github.com/bearfield/dot-devcontainer-debian-fish-bookworm

--- a/docker/config.fish
+++ b/docker/config.fish
@@ -6,3 +6,12 @@ set -g theme_newline_cursor yes
 set fish_color_command brpurple
 
 set -x CLOUDSDK_ACTIVE_CONFIG_NAME
+
+# Python aliases
+alias py="python3"
+alias pip="uv pip"
+alias pytest="uv tool run pytest"
+alias ruff="uv tool run ruff"
+alias black="uv tool run black"
+alias mypy="uv tool run mypy"
+alias ipython="uv tool run ipython"


### PR DESCRIPTION
## Summary
- Python 3.13（最新版）をuvでインストール
- 包括的なPython開発ツールの追加
- 適切な環境変数設定とFish shellエイリアスの追加

## Changes
### Docker環境
- Python 3.13をuvを使用してインストール
- システム全体でアクセス可能なPythonインストール（`/opt/uv/python`）
- Python開発用パッケージの追加（`python3-dev`, `build-essential`, `libffi-dev`）

### Python開発ツール
- **ruff**: 高速なPythonリンター＆フォーマッター
- **mypy**: 静的型チェッカー
- **black**: コードフォーマッター
- **pytest**: テストフレームワーク
- **ipython**: 強化された対話型Pythonシェル
- **poetry**: 依存関係管理・パッケージングツール
- **pipx**: Pythonアプリケーションの独立インストール
- **httpie**: HTTPクライアント（API開発用）
- **yq**: YAML/JSON/XML/CSVプロセッサー

### 環境設定
- `PYTHONUNBUFFERED=1`: Dockerログのリアルタイム出力
- `PYTHONDONTWRITEBYTECODE=1`: .pycファイルの生成を無効化
- `UV_SYSTEM_PYTHON=1`: システムPythonの使用を許可

### Fish Shellエイリアス
- `py` → `python3`
- `pip` → `uv pip`
- `pytest`, `ruff`, `black`, `mypy`, `ipython` → 各uvツールコマンド

### ドキュメント更新
- CLAUDE.mdにPython開発環境の詳細を追加
- README.mdに新しいPython機能を追加
- ビルドフロー図を更新

## Test plan
- [x] Docker buildが正常に完了する
- [x] Python 3.13が正しくインストールされている
- [x] すべての開発ツールが正常に動作する
- [x] devuserでPythonとツールにアクセス可能
- [x] エイリアスが正しく設定されている

🤖 Generated with [Claude Code](https://claude.ai/code)