### PR TITLE
devcontainerのマウント設定を読み取り専用に変更

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,10 +3,10 @@
     "image": "ghcr.io/bearfield/debian-fish:bookworm",
     "remoteUser": "${localEnv:USER}",
     "mounts": [
-        "source=${localEnv:HOME}/devcontainer_conf/.gitconfig_linux,target=/home/${localEnv:USER}/.gitconfig,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.config/gcloud,target=/home/${localEnv:USER}/.config/gcloud,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind,consistency=cached",
-        "source=${localEnv:HOME}/.claude/CLAUDE.md,target=/home/${localEnv:USER}/.claude/CLAUDE.md,type=bind,consistency=cached"
+        "source=${localEnv:HOME}/devcontainer_conf/.gitconfig_linux,target=/home/${localEnv:USER}/.gitconfig,type=bind,consistency=cached,readonly",
+        "source=${localEnv:HOME}/.config/gcloud,target=/home/${localEnv:USER}/.config/gcloud,type=bind,consistency=cached,readonly",
+        "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind,consistency=cached,readonly",
+        "source=${localEnv:HOME}/.claude/CLAUDE.md,target=/home/${localEnv:USER}/.claude/CLAUDE.md,type=bind,consistency=cached,readonly"
     ],
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {


### PR DESCRIPTION
## 概要
devcontainerでマウントしているホスト側のファイル・ディレクトリを読み取り専用に変更しました。

## 変更内容
以下のマウントポイントに`readonly`オプションを追加：
- `~/.gitconfig_linux` → `/home/${USER}/.gitconfig`
- `~/.config/gcloud` → `/home/${USER}/.config/gcloud`
- `~/.ssh` → `/home/${USER}/.ssh`
- `~/.claude/CLAUDE.md` → `/home/${USER}/.claude/CLAUDE.md`

## 目的
コンテナ内からホスト側の重要な設定ファイルへの意図しない変更を防ぐため。

## テスト方法
1. devcontainerを再起動
2. コンテナ内でマウントされたファイルへの書き込みができないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)