### PR TITLE
Claude Codeをユーザー権限でインストールするように変更

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -162,7 +162,9 @@ RUN fisher install bearfield/peco_select_gcp_project
 # power line style
 RUN fisher install oh-my-fish/theme-bobthefish
 # install claude-code as user
-RUN npm install --prefix /home/$USER_NAME/.npm-global @anthropic-ai/claude-code
+RUN mkdir -p /home/$USER_NAME/.npm-global && \
+    npm config set prefix /home/$USER_NAME/.npm-global && \
+    npm install -g @anthropic-ai/claude-code
 # copy config.fish
 COPY config.fish /home/$USER_NAME/.config/fish/config.fish
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -117,11 +117,10 @@ RUN install -m 0755 -d /etc/apt/keyrings \
     && apt-get autoremove -y \
     && apt-get clean -y \
 	&& rm -rf /var/lib/apt/lists/*
-# install claude-code
+# install Node.js (needed for claude-code)
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
     && npm install -g npm@latest \
-    && npm install -g @anthropic-ai/claude-code \
     # crean up
     && apt-get autoremove -y \
     && apt-get clean -y \
@@ -162,7 +161,8 @@ RUN fisher install bearfield/peco_select_gce_ssh
 RUN fisher install bearfield/peco_select_gcp_project
 # power line style
 RUN fisher install oh-my-fish/theme-bobthefish
-#
+# install claude-code as user
+RUN npm install --prefix /home/$USER_NAME/.npm-global @anthropic-ai/claude-code
 # copy config.fish
 COPY config.fish /home/$USER_NAME/.config/fish/config.fish
 
@@ -173,6 +173,8 @@ RUN mkdir -p /home/$USER_NAME/.claude && \
 
 # set env
 ENV DEBIAN_FRONTEND=dialog
+# Add npm global bin to PATH for user
+ENV PATH="/home/$USER_NAME/.npm-global/bin:$PATH"
 # Python environment variables
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/docker/config.fish
+++ b/docker/config.fish
@@ -15,3 +15,6 @@ alias ruff="uv tool run ruff"
 alias black="uv tool run black"
 alias mypy="uv tool run mypy"
 alias ipython="uv tool run ipython"
+
+# Add npm user global bin to PATH
+set -gx PATH /home/$USER/.npm-global/bin $PATH


### PR DESCRIPTION
## 概要
Claude Codeの自動アップデートが権限不足で失敗する問題を解決するため、インストール方法をroot権限からユーザー権限に変更しました。

## 背景
現在のインストール方法では、Claude Codeがroot権限で `/usr/local/lib/node_modules` にインストールされているため、ユーザーが自動アップデートを実行できません。

## 変更内容
1. **Dockerfile**:
   - Claude Codeのインストールをユーザー権限で実行するように変更
   - `npm install --prefix /home/$USER_NAME/.npm-global` を使用してユーザーのホームディレクトリ配下にインストール
   - 環境変数PATHにユーザーのnpmグローバルbinディレクトリを追加

2. **config.fish**:
   - Fish shellの設定でもPATHにユーザーのnpmグローバルbinディレクトリを追加

## メリット
- Claude Codeの自動アップデートが正常に動作するようになる
- ユーザーが所有権を持つディレクトリにインストールされるため、権限の問題が解消される

## テスト方法
1. イメージをビルド: `make test`
2. コンテナ内で `which claude` を実行して、パスが `/home/devuser/.npm-global/bin/claude` になっていることを確認
3. `claude update` を実行して、自動アップデートが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)