### PR TITLE
VS Code DevContainer設定にPython開発環境の設定を追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,17 @@
                 "workbench.colorCustomizations": {
                     "statusBar.background": "#859900",
                     "statusBar.foreground": "#FFFFFF"
-                }
+                },
+                "python.defaultInterpreterPath": "uv",
+                "python.linting.enabled": true,
+                "python.linting.pylintEnabled": true,
+                "python.linting.flake8Enabled": true,
+                "python.linting.mypyEnabled": true,
+                "python.linting.lintOnSave": true,
+                "python.formatting.provider": "black",
+                "python.linting.pylintArgs": ["--max-line-length=100"],
+                "python.linting.flake8Args": ["--max-line-length=100"],
+                "python.linting.mypyArgs": ["--ignore-missing-imports"]
             },
             "extensions": [
                 "wayou.vscode-todo-highlight",
@@ -46,7 +56,9 @@
                 "github.copilot-chat",
                 "vstirbu.vscode-mermaid-preview",
                 "anthropic.claude-code",
-                "aquasecurityofficial.trivy-vulnerability-scanner"
+                "aquasecurityofficial.trivy-vulnerability-scanner",
+                "ms-python.python",
+                "saoudrizwan.claude-dev"
             ]
         }
     }


### PR DESCRIPTION
## Summary
- DevContainerのVS Code設定にPython開発環境の設定を追加しました
- Python拡張機能とClaude Dev拡張機能を拡張機能リストに追加しました
- uvをデフォルトのPythonインタープリタとして設定し、各種Linterとフォーマッタの設定を追加しました

## 変更内容
1. **VS Code拡張機能の追加**
   - `ms-python.python`: Python開発の基本拡張機能
   - `saoudrizwan.claude-dev`: Claude開発支援拡張機能

2. **Python開発設定の追加**
   - デフォルトインタープリタ: `uv`（Dockerイメージにインストール済み）
   - Linter設定: pylint、flake8、mypy（保存時に自動実行）
   - フォーマッタ: black
   - 行の最大長: 100文字に統一

## Test plan
- [ ] DevContainerを再ビルドして正常に起動することを確認
- [ ] VS Code内でPythonファイルを開き、Linterが正常に動作することを確認
- [ ] Python拡張機能が正しくインストールされることを確認
- [ ] uvコマンドでPythonが実行できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)