### PR TITLE
codex-cliの導入とdevcontainerでの~/.codex ROマウント追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,12 @@
         "source=${localEnv:HOME}/.ssh,target=/home/${localEnv:USER}/.ssh,type=bind,consistency=cached,readonly",
         "source=${localEnv:HOME}/.claude/CLAUDE.md,target=/home/${localEnv:USER}/.claude/CLAUDE.md,type=bind,consistency=cached,readonly",
         "source=${localEnv:HOME}/.claude/settings.json,target=/home/${localEnv:USER}/.claude/settings.json,type=bind,consistency=cached,readonly",
+        "source=${localEnv:HOME}/.codex/AGENTS.md,target=/home/${localEnv:USER}/.codex/AGENTS.md,type=bind,consistency=cached,readonly",
+        "source=${localEnv:HOME}/.codex/config.toml,target=/home/${localEnv:USER}/.codex/config.toml,type=bind,consistency=cached,readonly",
+        "source=${localEnv:HOME}/.codex/denylist.txt,target=/home/${localEnv:USER}/.codex/denylist.txt,type=bind,consistency=cached,readonly",
+        "source=${localEnv:HOME}/.codex/allowlist.txt,target=/home/${localEnv:USER}/.codex/allowlist.txt,type=bind,consistency=cached,readonly",
+        "source=${localEnv:HOME}/.codex/policy.md,target=/home/${localEnv:USER}/.codex/policy.md,type=bind,consistency=cached,readonly",
+        "source=${localEnv:HOME}/.codex/prompts,target=/home/${localEnv:USER}/.codex/prompts,type=bind,consistency=cached,readonly",
         "source=${localEnv:HOME}/Documents/Cline,target=/home/${localEnv:USER}/Cline,type=bind,consistency=cached,readonly"
     ],
     "features": {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -164,7 +164,8 @@ RUN fisher install oh-my-fish/theme-bobthefish
 # install claude-code as user
 RUN mkdir -p /home/$USER_NAME/.npm-global && \
     npm config set prefix /home/$USER_NAME/.npm-global && \
-    npm install -g @anthropic-ai/claude-code
+    npm install -g @anthropic-ai/claude-code && \
+    npm install -g codex-cli
 # copy config.fish
 COPY config.fish /home/$USER_NAME/.config/fish/config.fish
 
@@ -172,6 +173,11 @@ COPY config.fish /home/$USER_NAME/.config/fish/config.fish
 RUN mkdir -p /home/$USER_NAME/.claude && \
     chown -R $USER_NAME:$USER_NAME /home/$USER_NAME/.claude && \
     chmod 755 /home/$USER_NAME/.claude
+
+# create .codex directory for Codex CLI settings and runtime files
+RUN mkdir -p /home/$USER_NAME/.codex && \
+    chown -R $USER_NAME:$USER_NAME /home/$USER_NAME/.codex && \
+    chmod 755 /home/$USER_NAME/.codex
 
 # set env
 ENV DEBIAN_FRONTEND=dialog


### PR DESCRIPTION
目的
- codex-cli を開発ユーザスコープで npm グローバルインストール
- devcontainer で ~/.codex 配下の設定ファイル群を RO マウント
- 実行時に必要な書き込み（auth/logs/state 等）はコンテナ内で許可

変更点
- docker/Dockerfile
  - 開発ユーザ（$USER_NAME）の npm グローバルに codex-cli を追加（最新版）
  - ~/.codex ディレクトリを作成し権限付与
- .devcontainer/devcontainer.json
  - ~/.codex/AGENTS.md, config.toml, allowlist.txt, denylist.txt, policy.md, prompts を RO マウントとして追加

背景
- ~/.codex をディレクトリ全体で RO マウントすると auth や log の書き込みで起動に失敗するため、必要ファイルのみ RO に限定

動作確認
- Makefile の以下ターゲットでビルド成功を確認
  - test.build.arm64
  - test.build.amd64

影響範囲
- 既存の利用方法に大きな変更はなし
- prompts はホスト側 ~/.codex/prompts を参照（RO）

注意点
- auth/logs/state をホスト側に永続化したい場合は、必要ディレクトリを個別に RW マウントする運用を推奨