### PR TITLE
ビルド: Dockerイメージにripgrepを追加

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update \
         gcc \
         less \
         jq \
+        ripgrep \
         tree \
         zip \
         unzip \


### PR DESCRIPTION
## 変更内容の概要
- Docker イメージに ripgrep (rg) を追加。
- `apt-get install --no-install-recommends` の既存ブロックへ 1 行追記のみ。

## 変更の目的
- コンテナ内での高速コード検索を可能にし、開発効率を向上。

## テスト結果・確認項目
- [x] `docker/Dockerfile` がビルド可能であること。
- 任意確認:
  - `make test.build.arm64`
  - `docker run --rm -it ghcr.io/bearfield/debian-fish:test.bookworm.arm64 rg --version`

## 関連Issue / Backlog課題
- なし（必要に応じて追記）。

## 次のステップ
- 利用頻度に応じて README へ補足（例: rg の活用例）。