### PR TITLE
環境: codexの既定承認モードをon-failureに設定

### DIFF
--- a/docker/config.fish
+++ b/docker/config.fish
@@ -18,3 +18,8 @@ alias ipython="uv tool run ipython"
 
 # Add npm user global bin to PATH
 set -gx PATH /home/$USER/.npm-global/bin $PATH
+
+# codex: default approval mode wrapper
+function codex
+    command codex --approval on-failure $argv
+end


### PR DESCRIPTION
## 変更内容の概要
- DevContainer の fish 設定に `codex` ラッパー関数を追加。
- 既定で `codex --approval on-failure` を適用（引数は `$argv` で透過的に伝搬）。

## 変更の目的
- コマンド実行時の承認ダイアログ頻度を低減し、日常的な開発フローを高速化。

## テスト結果・確認項目
- [x] `docker/config.fish` に function を定義し、`command codex` で自己再帰を回避。
- 任意確認（コンテナ内）:
  - `type -a codex` で function が優先されること。
  - `codex --help` が表示されること。

## 関連Issue / Backlog課題
- なし（必要に応じて追記）。

## 次のステップ
- 必要に応じて AGENTS.md/README に運用方針を追記。