### PR TITLE
環境: codexの承認フラグ修正とcdx追加

### DIFF
--- a/docker/config.fish
+++ b/docker/config.fish
@@ -19,7 +19,12 @@ alias ipython="uv tool run ipython"
 # Add npm user global bin to PATH
 set -gx PATH /home/$USER/.npm-global/bin $PATH
 
-# codex: default approval mode wrapper
+# codex: default approval mode wrapper (approval only)
 function codex
-    command codex --approval on-failure $argv
+    command codex --ask-for-approval on-failure $argv
+end
+
+# cdx: short form wrapper
+function cdx
+    command codex --ask-for-approval on-failure $argv
 end


### PR DESCRIPTION
## 変更内容の概要
- `docker/config.fish` の codex ラッパーを修正：
  - 誤: `--approval on-failure`
  - 正: `--ask-for-approval on-failure`
- 短縮形 `cdx` を追加（同一の既定フラグを適用）。

## 変更の目的
- 正しいフラグに統一して挙動の不整合を解消。
- `codex` がオプション不正で起動できない状況でも、`cdx` からヘルプや通常利用を可能にする回避策。

## テスト結果・確認項目（DevContainer内）
- [x] `type -a codex` / `type -a cdx` で function が先に解決される。
- [x] `cdx --help` が正常に表示される。

## 関連Issue / Backlog課題
- なし（必要に応じて追記）。

## 次のステップ
- ドキュメント（README/AGENTS.md）に `cdx` 推奨利用を追記検討。