### PR TITLE
Codexラッパーを設定駆動化し、cdxを簡素化

### DIFF
--- a/docker/config.fish
+++ b/docker/config.fish
@@ -19,12 +19,7 @@ alias ipython="uv tool run ipython"
 # Add npm user global bin to PATH
 set -gx PATH /home/$USER/.npm-global/bin $PATH
 
-# codex: default approval mode wrapper (approval only)
-function codex
-    command codex --ask-for-approval on-failure $argv
-end
-
-# cdx: short form wrapper
+# cdx: short form wrapper (config-driven)
 function cdx
-    command codex --ask-for-approval on-failure $argv
+    command codex $argv
 end


### PR DESCRIPTION
## 概要
- 固定の Codex ラッパーを削除し、`cdx` を設定駆動化しました。
- 承認モードの指定は利用者／環境設定に委譲します。

## 背景
- AGENTS.md セクション4（コマンド利用ガイド）に準拠し、承認モードをコードに固定しない方針とするため。
- `--ask-for-approval on-failure` のハードコードが状況と乖離するケースがあり、混乱を招くため。

## 変更内容
- `docker/config.fish`
  - 削除: `codex` 関数（固定フラグ `--ask-for-approval on-failure` を付与していたラッパー）。
  - 変更: `cdx` 関数 → 単純委譲のみにし、`command codex $argv` へ。
- 既存の使い方は維持され、必要に応じてフラグは呼び出し側で指定可能です。

## 動作確認
- Fish セッションで以下を確認:
  - `functions cdx` が定義されている。
  - `cdx --help` が従来どおり利用可能。
  - Codex 実行時、承認モードがグローバル設定／ポリシーに従って動作。

## 影響範囲
- 影響は `docker/config.fish` のみ。後方互換性あり。
- スクリプトやドキュメントで `on-failure` の固定を前提にしている場合は、記載更新が必要な可能性があります。

## 関連
- `AGENTS.md`: セクション4 コマンド利用ガイド
- `work/policy.md`: 承認モードとコマンド方針（参照）

## 次のステップ
- 必要に応じて、チーム既定の承認モードを `work/policy.md` に明記。
- ハードコード前提の記載が他ドキュメントにあれば更新。