### PR TITLE
ci: update scheduled workflow time to reduce load

### DIFF
--- a/.github/workflows/debian-fish-bookworm.yaml
+++ b/.github/workflows/debian-fish-bookworm.yaml
@@ -12,7 +12,7 @@ on:
       - 'docker/**'
       - '.github/workflows/debian-fish-bookworm.yaml'
   schedule:
-    - cron: '0 18 * * *'
+    - cron: '17 18 * * *'
   workflow_dispatch:
 jobs:
   build:


### PR DESCRIPTION
## 概要
GitHub Actionsのスケジュールワークフローの実行時刻を変更します。

## 変更内容
- cron式を `'0 18 * * *'` から `'17 18 * * *'` に変更

## 理由
GitHub Actionsのスケジュールワークフローは、多くのユーザーが「0分」（例：18:00、0:00など）に設定する傾向があり、その時刻にサーバー負荷が集中します。

分をランダムな値（17分）に設定することで：
- サーバー負荷の分散に貢献
- ワークフローの実行遅延を軽減

参考: [GitHub Actions のワークフロー構文](https://docs.github.com/ja/actions/using-workflows/events-that-trigger-workflows#schedule)